### PR TITLE
feat: event-specific channel routing + commands, status enhancements, and release dedup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "^6.8.2",
+        "@prisma/client": "^6.13.0",
         "axios": "^1.9.0",
         "discord.js": "^14.19.3",
         "dotenv": "^16.5.0",
@@ -18,10 +18,35 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.2",
-        "prisma": "^6.8.2"
+        "prisma": "^6.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -152,9 +177,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.8.2.tgz",
-      "integrity": "sha512-5II+vbyzv4si6Yunwgkj0qT/iY0zyspttoDrL3R4BYgLdp42/d2C8xdi9vqkrYtKt9H32oFIukvyw3Koz5JoDg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.13.0.tgz",
+      "integrity": "sha512-8m2+I3dQovkV8CkDMluiwEV1TxV9EXdT6xaCz39O6jYw7mkf5gwfmi+cL4LJsEPwz5tG7sreBwkRpEMJedGYUQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -174,63 +199,66 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.8.2.tgz",
-      "integrity": "sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.13.0.tgz",
+      "integrity": "sha512-OYMM+pcrvj/NqNWCGESSxVG3O7kX6oWuGyvufTUNnDw740KIQvNyA4v0eILgkpuwsKIDU36beZCkUtIt0naTog==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jiti": "2.4.2"
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.16.12",
+        "read-package-up": "11.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
-      "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.13.0.tgz",
+      "integrity": "sha512-um+9pfKJW0ihmM83id9FXGi5qEbVJ0Vxi1Gm0xpYsjwUBnw6s2LdPBbrsG9QXRX46K4CLWCTNvskXBup4i9hlw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.8.2.tgz",
-      "integrity": "sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.13.0.tgz",
+      "integrity": "sha512-D+1B79LFvtWA0KTt8ALekQ6A/glB9w10ETknH5Y9g1k2NYYQOQy93ffiuqLn3Pl6IPJG3EsK/YMROKEaq8KBrA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2",
-        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-        "@prisma/fetch-engine": "6.8.2",
-        "@prisma/get-platform": "6.8.2"
+        "@prisma/debug": "6.13.0",
+        "@prisma/engines-version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
+        "@prisma/fetch-engine": "6.13.0",
+        "@prisma/get-platform": "6.13.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e.tgz",
-      "integrity": "sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==",
+      "version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd.tgz",
+      "integrity": "sha512-MpPyKSzBX7P/ZY9odp9TSegnS/yH3CSbchQE9f0yBg3l2QyN59I6vGXcoYcqKC9VTniS1s18AMmhyr1OWavjHg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.8.2.tgz",
-      "integrity": "sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.13.0.tgz",
+      "integrity": "sha512-grmmq+4FeFKmaaytA8Ozc2+Tf3BC8xn/DVJos6LL022mfRlMZYjT3hZM0/xG7+5fO95zFG9CkDUs0m1S2rXs5Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2",
-        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-        "@prisma/get-platform": "6.8.2"
+        "@prisma/debug": "6.13.0",
+        "@prisma/engines-version": "6.13.0-35.361e86d0ea4987e9f53a565309b3eed797a6bcbd",
+        "@prisma/get-platform": "6.13.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.8.2.tgz",
-      "integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.13.0.tgz",
+      "integrity": "sha512-Nii2pX50fY4QKKxQwm7/vvqT6Ku8yYJLZAFX4e2vzHwRdMqjugcOG5hOSLjxqoXb0cvOspV70TOhMzrw8kqAnw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2"
+        "@prisma/debug": "6.13.0"
       }
     },
     "node_modules/@sapphire/async-queue": {
@@ -266,6 +294,13 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
@@ -274,6 +309,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -411,6 +453,65 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -465,6 +566,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -483,6 +594,23 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -540,6 +668,23 @@
         }
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -557,6 +702,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/discord-api-types": {
       "version": "0.38.8",
@@ -595,9 +747,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -625,6 +777,17 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "3.16.12",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
+      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -737,6 +900,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -771,6 +964,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/follow-redirects": {
@@ -908,6 +1114,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -982,6 +1206,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1016,6 +1253,19 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/index-to-position": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1085,14 +1335,21 @@
       "license": "MIT"
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -1105,6 +1362,13 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",
@@ -1191,6 +1455,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -1220,6 +1491,21 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1228,6 +1514,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
+      "integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.2",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.2.0",
+        "tinyexec": "^1.0.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1241,6 +1547,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1263,6 +1576,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1280,6 +1611,20 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.16.0",
@@ -1370,6 +1715,13 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1381,6 +1733,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
+      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/postgres-array": {
@@ -1423,15 +1787,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.8.2.tgz",
-      "integrity": "sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.13.0.tgz",
+      "integrity": "sha512-dfzORf0AbcEyyzxuv2lEwG8g+WRGF/qDQTpHf/6JoHsyF5MyzCEZwClVaEmw3WXcobgadosOboKUgQU0kFs9kw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.8.2",
-        "@prisma/engines": "6.8.2"
+        "@prisma/config": "6.13.0",
+        "@prisma/engines": "6.13.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -1474,6 +1838,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -1511,6 +1892,55 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readdirp": {
@@ -1572,7 +2002,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1709,6 +2139,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "devOptional": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "devOptional": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -1739,6 +2205,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1784,6 +2257,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1820,6 +2306,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1827,6 +2326,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/gittrack/gittrack-discord-bot#readme",
   "dependencies": {
-    "@prisma/client": "^6.8.2",
+    "@prisma/client": "^6.13.0",
     "axios": "^1.9.0",
     "discord.js": "^14.19.3",
     "dotenv": "^16.5.0",
@@ -37,8 +37,8 @@
     "pg": "^8.16.0"
   },
   "devDependencies": {
-    "prisma": "^6.8.2",
-    "nodemon": "^3.1.2"
+    "nodemon": "^3.1.2",
+    "prisma": "^6.13.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Repository {
   server                Server            @relation(fields: [serverId], references: [id])
   serverId              String
   trackedBranches       TrackedBranch[]
+  eventChannels         RepositoryEventChannel[]
   createdAt             DateTime          @default(now())
   updatedAt             DateTime          @updatedAt
 
@@ -49,6 +50,18 @@ model TrackedBranch {
   updatedAt      DateTime   @updatedAt
 
   @@unique([repositoryId, branchName, channelId]) // A repo can track a branch in different channels
+}
+
+model RepositoryEventChannel {
+  id            String      @id @default(cuid())
+  repository    Repository  @relation(fields: [repositoryId], references: [id])
+  repositoryId  String
+  eventType     String      // e.g., "issues", "release", "star", etc.
+  channelId     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+
+  @@unique([repositoryId, eventType])
 }
 
 model ErrorLog {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -31,6 +31,8 @@ module.exports = {
           value: 
             '• `/remove-repo` - Remove a repository from tracking\n' +
             '• `/set-default-channel` - Set the default notification channel\n' +
+            '• `/set-event-channel` - Route a specific event (e.g., issues, release) to a channel\n' +
+            '• `/remove-event-channel` - Remove a specific event route from a repository\n' +
             '• `/reset` - Reset all bot data for this server (Admin only)',
           inline: false
         },
@@ -47,6 +49,15 @@ module.exports = {
       })
       .setTimestamp();
 
-    await interaction.reply({ embeds: [embed], ephemeral: true });
+    const components = [
+      new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setLabel('GitHub Repo')
+          .setStyle(ButtonStyle.Link)
+          .setURL('https://github.com/luuccaaaa/gittrack-discord-bot')
+      )
+    ];
+
+    await interaction.reply({ embeds: [embed], components, ephemeral: true });
   },
 };

--- a/src/commands/remove-event-channel.js
+++ b/src/commands/remove-event-channel.js
@@ -1,0 +1,165 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+// Supported non-branch events (should mirror routing-capable events)
+const ROUTABLE_EVENTS = [
+  'issues',
+  'release',
+  'star',
+  'fork',
+  'create',
+  'delete',
+  'pull_request',
+  'issue_comment',
+  'milestone',
+  'ping',
+];
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('remove-event-channel')
+    .setDescription('Remove a configured event-to-channel route for a repository')
+    .addStringOption(option =>
+      option.setName('repository')
+        .setDescription('The GitHub repository')
+        .setRequired(true)
+        .setAutocomplete(true)
+    )
+    .addStringOption(option =>
+      option.setName('event')
+        .setDescription('GitHub event to remove routing for')
+        .setRequired(true)
+        .setAutocomplete(true)
+    ),
+
+  async autocomplete(interaction, prisma) {
+    try {
+      const focused = interaction.options.getFocused(true); // { name, value }
+      const guildId = interaction.guildId;
+
+      if (focused.name === 'repository') {
+        const focusedValue = focused.value?.toLowerCase?.() || '';
+        const server = await prisma.server.findUnique({
+          where: { guildId },
+          include: { repositories: true }
+        });
+
+        if (!server || !server.repositories || server.repositories.length === 0) {
+          return interaction.respond([
+            { name: 'No repositories found. Use /setup to add one.', value: 'no-repos' }
+          ]);
+        }
+
+        const choices = server.repositories
+          .filter(r => r.url.toLowerCase().includes(focusedValue))
+          .map(repo => {
+            const parts = repo.url.split('/');
+            const name = parts[parts.length - 1] || parts[parts.length - 2] || repo.url;
+            return { name: `${name} (${repo.url})`, value: repo.id };
+          })
+          .slice(0, 25);
+        return interaction.respond(choices.length ? choices : [{ name: 'No matching repositories found', value: 'no-match' }]);
+      }
+
+      if (focused.name === 'event') {
+        // Suggest only currently mapped events for the selected repository
+        const repositoryId = interaction.options.getString('repository');
+        if (!repositoryId || ['no-repos', 'no-match', 'error'].includes(repositoryId)) {
+          return interaction.respond([{ name: 'Select a repository first', value: 'no-repo-selected' }]);
+        }
+        const mappings = await prisma.repositoryEventChannel.findMany({
+          where: { repositoryId }
+        });
+        const available = mappings.map(m => m.eventType).filter((v, i, arr) => arr.indexOf(v) === i);
+        const filtered = available
+          .filter(ev => ev.toLowerCase().includes((focused.value || '').toLowerCase()))
+          .slice(0, 25)
+          .map(ev => ({ name: ev, value: ev }));
+        if (filtered.length > 0) return interaction.respond(filtered);
+
+        // Fallback: show routable events to guide user
+        return interaction.respond(ROUTABLE_EVENTS.map(ev => ({ name: ev, value: ev })).slice(0, 25));
+      }
+
+      return interaction.respond([]);
+    } catch (error) {
+      console.error('Autocomplete error in remove-event-channel:', error);
+      try {
+        return interaction.respond([{ name: 'Error loading autocomplete', value: 'error' }]);
+      } catch {}
+    }
+  },
+
+  async execute(interaction, prisma) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const repositoryId = interaction.options.getString('repository');
+    const eventType = interaction.options.getString('event');
+    const guildId = interaction.guildId;
+
+    if (!repositoryId || ['no-repos', 'no-match', 'error', 'no-repo-selected'].includes(repositoryId)) {
+      await interaction.editReply('Please select a valid repository.');
+      return;
+    }
+
+    if (!eventType || !ROUTABLE_EVENTS.includes(eventType)) {
+      await interaction.editReply('Please select a valid event to remove.');
+      return;
+    }
+
+    try {
+      const repository = await prisma.repository.findFirst({
+        where: { id: repositoryId, server: { guildId } }
+      });
+      if (!repository) {
+        await interaction.editReply('Repository not found.');
+        return;
+      }
+
+      const existing = await prisma.repositoryEventChannel.findFirst({
+        where: { repositoryId: repository.id, eventType }
+      });
+
+      if (!existing) {
+        const embed = new EmbedBuilder()
+          .setColor(0xF59E0B)
+          .setTitle('No Event Route Found')
+          .setDescription('There is no event-specific routing configured for this selection.')
+          .addFields(
+            { name: 'Repository', value: repository.url, inline: false },
+            { name: 'Event', value: `\`${eventType}\``, inline: true }
+          )
+          .setTimestamp();
+        await interaction.editReply({ embeds: [embed] });
+        return;
+      }
+
+      await prisma.repositoryEventChannel.delete({ where: { id: existing.id } });
+
+      const displayUrl = repository.url.endsWith('.git') ? repository.url.slice(0, -4) : repository.url;
+      const formattedEvent = eventType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+      const embed = new EmbedBuilder()
+        .setColor(0x10B981)
+        .setTitle('Event Routing Removed')
+        .setDescription('The event-to-channel route has been removed:')
+        .addFields(
+          { name: 'Repository', value: displayUrl, inline: false },
+          { name: 'Event', value: `\`${formattedEvent}\``, inline: true }
+        )
+        .setFooter({ text: 'Use /status to confirm current routes.' })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      console.error('Error removing event channel:', error);
+      const embed = new EmbedBuilder()
+        .setColor(0xEF4444)
+        .setTitle('Failed to Remove Event Route')
+        .setDescription('An error occurred while removing the event routing configuration:')
+        .addFields({ name: 'Error', value: `\`${error.message}\`` })
+        .setTimestamp();
+      await interaction.editReply({ embeds: [embed] });
+    }
+  }
+};
+
+

--- a/src/commands/set-event-channel.js
+++ b/src/commands/set-event-channel.js
@@ -1,0 +1,170 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+// Event types eligible for per-event routing (non-branch specific)
+const ROUTABLE_EVENTS = [
+  { name: 'issues', value: 'issues' },
+  { name: 'release', value: 'release' },
+  { name: 'star', value: 'star' },
+  { name: 'fork', value: 'fork' },
+  { name: 'create', value: 'create' },
+  { name: 'delete', value: 'delete' },
+  { name: 'pull_request', value: 'pull_request' },
+  { name: 'issue_comment', value: 'issue_comment' },
+  { name: 'milestone', value: 'milestone' },
+  { name: 'ping', value: 'ping' },
+];
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('set-event-channel')
+    .setDescription('Route a specific GitHub event (non-branch) to a channel for a repository')
+    .addStringOption(option =>
+      option.setName('repository')
+        .setDescription('The GitHub repository')
+        .setRequired(true)
+        .setAutocomplete(true))
+    .addStringOption(option => {
+      let builder = option
+        .setName('event')
+        .setDescription('GitHub event to route (non-branch)')
+        .setRequired(true);
+      // Add choices for better UX
+      ROUTABLE_EVENTS.forEach(ev => { builder = builder.addChoices({ name: ev.name, value: ev.value }); });
+      return builder;
+    })
+    .addChannelOption(option =>
+      option.setName('channel')
+        .setDescription('Channel to send this event to')
+        .addChannelTypes(0) // GuildText only
+        .setRequired(true)
+    ),
+
+  async autocomplete(interaction, prisma) {
+    const focusedValue = interaction.options.getFocused()?.toLowerCase?.() || '';
+    const guildId = interaction.guildId;
+
+    try {
+      const server = await prisma.server.findUnique({
+        where: { guildId },
+        include: { repositories: true }
+      });
+
+      if (!server || !server.repositories || server.repositories.length === 0) {
+        return interaction.respond([
+          { name: 'No repositories found. Use /setup to add one.', value: 'no-repos' }
+        ]);
+      }
+
+      const filtered = server.repositories
+        .filter(repo => repo.url.toLowerCase().includes(focusedValue))
+        .map(repo => {
+          const urlParts = repo.url.split('/');
+          const repoName = urlParts[urlParts.length - 1] || urlParts[urlParts.length - 2] || repo.url;
+          return { name: `${repoName} (${repo.url})`, value: repo.id };
+        })
+        .slice(0, 25);
+
+      await interaction.respond(filtered.length > 0 ? filtered : [
+        { name: 'No matching repositories found', value: 'no-match' }
+      ]);
+    } catch (error) {
+      console.error('Autocomplete error in set-event-channel:', error);
+      await interaction.respond([
+        { name: 'Error fetching repositories', value: 'error' }
+      ]);
+    }
+  },
+
+  async execute(interaction, prisma) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const repositoryId = interaction.options.getString('repository');
+    const eventType = interaction.options.getString('event');
+    const channel = interaction.options.getChannel('channel');
+    const guildId = interaction.guildId;
+
+    if (!channel || !channel.isTextBased()) {
+      await interaction.editReply('The selected channel must be a text-based channel.');
+      return;
+    }
+
+    if (repositoryId === 'no-repos' || repositoryId === 'no-match' || repositoryId === 'error') {
+      await interaction.editReply('Please set up a repository first using the /setup command.');
+      return;
+    }
+
+    if (!ROUTABLE_EVENTS.find(e => e.value === eventType)) {
+      await interaction.editReply('Invalid event type. Choose one of the provided events.');
+      return;
+    }
+
+    try {
+      const repository = await prisma.repository.findFirst({
+        where: {
+          id: repositoryId,
+          server: { guildId }
+        },
+        include: { server: true }
+      });
+
+      if (!repository) {
+        await interaction.editReply('Repository not found. Please use the autocomplete to select a valid repository.');
+        return;
+      }
+
+      // Upsert mapping
+      const existing = await prisma.repositoryEventChannel.findFirst({
+        where: { repositoryId: repository.id, eventType }
+      });
+
+      let statusText = 'Created';
+      if (existing) {
+        await prisma.repositoryEventChannel.update({
+          where: { id: existing.id },
+          data: { channelId: channel.id }
+        });
+        statusText = 'Updated';
+      } else {
+        await prisma.repositoryEventChannel.create({
+          data: {
+            repositoryId: repository.id,
+            eventType,
+            channelId: channel.id
+          }
+        });
+      }
+
+      // Nicely formatted embedded response
+      const displayUrl = repository.url.endsWith('.git') ? repository.url.slice(0, -4) : repository.url;
+      const formattedEvent = eventType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+      const embed = new EmbedBuilder()
+        .setColor(0x3B82F6)
+        .setTitle('Event Routing Saved')
+        .setDescription('GitHub event routing has been configured for this repository:')
+        .addFields(
+          { name: 'Repository', value: displayUrl, inline: false },
+          { name: 'Event', value: `\`${formattedEvent}\``, inline: true },
+          { name: 'Channel', value: `<#${channel.id}>`, inline: true },
+          { name: 'Status', value: statusText, inline: true }
+        )
+        .setFooter({ text: 'Use /status to view all event routes and branch links.' })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      console.error('Error setting event channel:', error);
+      const embed = new EmbedBuilder()
+        .setColor(0xEF4444)
+        .setTitle('Failed to Set Event Channel')
+        .setDescription('An error occurred while saving the event routing configuration:')
+        .addFields(
+          { name: 'Error', value: `\`${error.message}\`` }
+        )
+        .setTimestamp();
+      await interaction.editReply({ embeds: [embed] });
+    }
+  }
+};
+
+

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -17,7 +17,8 @@ module.exports = {
         include: {
           repositories: {
             include: {
-              trackedBranches: true
+              trackedBranches: true,
+              eventChannels: true
             }
           }
         }
@@ -195,6 +196,22 @@ module.exports = {
             branchDisplay = 'No branches configured';
           }
 
+          // Build event routing details (only show explicitly mapped events)
+          let eventRoutingDisplay = 'No event-specific routing configured';
+          if (repo.eventChannels && repo.eventChannels.length > 0) {
+            const byChannel = new Map(); // channelId -> [eventType]
+            for (const ec of repo.eventChannels) {
+              if (!byChannel.has(ec.channelId)) byChannel.set(ec.channelId, []);
+              byChannel.get(ec.channelId).push(ec.eventType);
+            }
+            const lines = [];
+            for (const [channelId, events] of byChannel.entries()) {
+              const sorted = events.sort();
+              lines.push(`**<#${channelId}>**: ${sorted.map(e => `\`${e}\``).join(', ')}`);
+            }
+            eventRoutingDisplay = lines.join('\n');
+          }
+
           // Check webhook status
           const webhookStatus = repo.webhookSecret 
             ? '✅ Webhook configured' 
@@ -207,7 +224,7 @@ module.exports = {
 
           embed.addFields({
             name: displayUrl,
-            value: `**Webhook Status**: ${webhookStatus}\n**Tracked Branches by Channel**:\n${branchDisplay}`,
+            value: `**Webhook Status**: ${webhookStatus}\n**Tracked Branches by Channel**:\n${branchDisplay}\n**Event Routing**:\n${eventRoutingDisplay}`,
             inline: false
           });
         }

--- a/src/handlers/milestoneAndWorkflowHandlers.js
+++ b/src/handlers/milestoneAndWorkflowHandlers.js
@@ -19,8 +19,11 @@ async function handleMilestoneEvent(req, res, payload, prisma, botClient, repoCo
 
     // Use repoContext directly as it's the validated one for this webhook
     const serverConfig = repoContext.server;
-    // Use the repository-specific notification channel
-    const channelId = repoContext.notificationChannelId || 'pending';
+    // Prefer event-specific channel for milestone events
+    const mapping = await prisma.repositoryEventChannel.findFirst({
+      where: { repositoryId: repoContext.id, eventType: 'milestone' }
+    });
+    const channelId = mapping?.channelId || repoContext.notificationChannelId || 'pending';
 
     if (channelId === 'pending') {
         console.warn(`Notification channel pending for repository ${repoUrl} on server ${serverConfig.guildId}`);


### PR DESCRIPTION
**Event routing**

- Added RepositoryEventChannel model for per-event channel mapping.
- Handlers prefer event-specific channels for: issues, issue_comment, pull_request, release, star, fork, create, delete, milestone, ping.
- Release handler now only processes action published to avoid duplicate notifications.

**Commands**

- /set-event-channel to route a specific event to a channel (embedded confirmation).
- /remove-event-channel to delete an event route (embedded confirmation).
- Status
- /status shows an “Event Routing” section per repository.

**Help**

- /help includes a “GitHub Repo” link button.

**Schema**

- Added RepositoryEventChannel table with unique (repositoryId, eventType).
