### PR TITLE
feat: /edit-event filters, unified issues+comments, PR comments toggle, strict opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,23 @@ GitTrack is an open-source Discord bot that monitors GitHub repository activity 
 | `/unlink` | Remove linked repository | `/unlink url:https://github.com/user/repo branch:main channel:#notifications` |
 | `/remove-repo` | Remove repository from tracking | `/remove-repo url:https://github.com/user/repo` |
 | `/set-default-channel` | Set default notification channel | `/set-default-channel repository:https://github.com/user/repo channel:#notifications` |
+| `/set-event-channel` | Route a non-branch event to a channel | `/set-event-channel repository:<repo> event:issues channel:#notifications` |
+| `/edit-event` | Configure event filters (issues, PRs, etc.) | `/edit-event repository:<repo> event:issues` |
 | `/status` | Check server configuration and limits | `/status` |
 | `/reset` | Reset all bot data (Admin only) | `/reset confirm:true` |
 | `/ping` | Check if bot is responsive | `/ping` |
 | `/help` | Display help information | `/help` |
 
 ## 🔧 Configuration
+### Per-event routing and filters
+
+- Use `/set-event-channel` to route a specific event (e.g. `issues`, `pull_request`, `release`, `star`, `fork`, `create`, `delete`, `milestone`, `ping`) to a channel.
+- Use `/edit-event` to toggle which sub-actions notify. Highlights:
+  - **Issues**: toggle actions like `opened`, `closed`, `reopened`, `assigned` (also controls `unassigned`), `labeled` (also controls `unlabeled`), and a dedicated `comments` toggle for issue comments.
+  - **Pull Requests**: toggle actions like `opened`, `closed`, `reopened`, plus a `comments` toggle which controls PR conversation comments, PR review comments, and review state "commented".
+  - Other events (e.g. `star`, `release`, `fork`, `create`, `delete`, `ping`) can be enabled per action. Notifications only send when explicitly enabled.
+- If no event-specific route exists, filters can still be edited; a mapping will be created using the repository's default channel on first toggle.
+
 
 ### Discord Bot Setup
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model RepositoryEventChannel {
   repositoryId  String
   eventType     String      // e.g., "issues", "release", "star", etc.
   channelId     String
+  config        Json?       // Optional per-event configuration (e.g., action filters)
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
 

--- a/src/commands/edit-event.js
+++ b/src/commands/edit-event.js
@@ -1,0 +1,224 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+// Supported routable non-branch events and their common actions
+const ROUTABLE_EVENTS = [
+  { name: 'issues', value: 'issues' },
+  { name: 'pull_request', value: 'pull_request' },
+  { name: 'release', value: 'release' },
+  { name: 'star', value: 'star' },
+  { name: 'fork', value: 'fork' },
+  { name: 'create', value: 'create' },
+  { name: 'delete', value: 'delete' },
+  { name: 'milestone', value: 'milestone' },
+  { name: 'ping', value: 'ping' },
+];
+
+// Minimal action presets per event (extendable)
+const EVENT_ACTION_PRESETS = {
+  issues: ['opened', 'closed', 'reopened', 'edited', 'labeled', 'assigned', 'comments'],
+  pull_request: ['opened', 'closed', 'reopened', 'comments'],
+  release: ['published'],
+  star: ['created', 'deleted'],
+  fork: ['created'],
+  create: ['created'],
+  delete: ['deleted'],
+  milestone: ['created', 'closed', 'opened'],
+  ping: ['ping']
+};
+
+function formatRepoUrlForDisplay(url) {
+  return url && url.endsWith('.git') ? url.slice(0, -4) : url;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('edit-event')
+    .setDescription('Configure filters for a non-branch GitHub event on a repository')
+    .addStringOption(option =>
+      option.setName('repository')
+        .setDescription('The GitHub repository')
+        .setRequired(true)
+        .setAutocomplete(true))
+    .addStringOption(option => {
+      let builder = option
+        .setName('event')
+        .setDescription('GitHub event to configure (non-branch)')
+        .setRequired(true);
+      ROUTABLE_EVENTS.forEach(ev => { builder = builder.addChoices({ name: ev.name, value: ev.value }); });
+      return builder;
+    }),
+
+  async autocomplete(interaction, prisma) {
+    const focusedValue = interaction.options.getFocused()?.toLowerCase?.() || '';
+    const guildId = interaction.guildId;
+
+    try {
+      const server = await prisma.server.findUnique({
+        where: { guildId },
+        include: { repositories: true }
+      });
+
+      if (!server || !server.repositories?.length) {
+        return interaction.respond([
+          { name: 'No repositories found. Use /setup to add one.', value: 'no-repos' }
+        ]);
+      }
+
+      const filtered = server.repositories
+        .filter(repo => repo.url.toLowerCase().includes(focusedValue))
+        .map(repo => {
+          const urlParts = repo.url.split('/');
+          const repoName = urlParts[urlParts.length - 1] || urlParts[urlParts.length - 2] || repo.url;
+          return { name: `${repoName} (${repo.url})`, value: repo.id };
+        })
+        .slice(0, 25);
+
+      await interaction.respond(filtered.length ? filtered : [{ name: 'No matching repositories found', value: 'no-match' }]);
+    } catch (error) {
+      console.error('Autocomplete error in edit-event:', error);
+      await interaction.respond([{ name: 'Error fetching repositories', value: 'error' }]);
+    }
+  },
+
+  async execute(interaction, prisma) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const repositoryId = interaction.options.getString('repository');
+    const eventType = interaction.options.getString('event');
+    const guildId = interaction.guildId;
+
+    if (repositoryId === 'no-repos' || repositoryId === 'no-match' || repositoryId === 'error') {
+      await interaction.editReply('Please set up a repository first using the /setup command.');
+      return;
+    }
+
+    try {
+      const repository = await prisma.repository.findFirst({
+        where: { id: repositoryId, server: { guildId } },
+        include: { server: true }
+      });
+
+      if (!repository) {
+        await interaction.editReply('Repository not found. Please use the autocomplete to select a valid repository.');
+        return;
+      }
+
+      const mapping = await prisma.repositoryEventChannel.findFirst({
+        where: { repositoryId: repository.id, eventType }
+      });
+
+      const displayUrl = formatRepoUrlForDisplay(repository.url);
+      const supportedActions = EVENT_ACTION_PRESETS[eventType] || [];
+      const currentConfig = (mapping && mapping.config) || {};
+      const actionsEnabled = currentConfig.actionsEnabled || supportedActions.reduce((acc, action) => {
+        acc[action] = action === 'comments' ? false : true;
+        return acc;
+      }, {});
+
+      const embed = new EmbedBuilder()
+        .setColor(0x3B82F6)
+        .setTitle('Edit Event Filters')
+        .setDescription('Toggle which actions for this event should trigger notifications:')
+        .addFields(
+          { name: 'Repository', value: displayUrl, inline: false },
+          { name: 'Event', value: `\`${eventType}\``, inline: true },
+          { name: 'Channel', value: mapping ? `<#${mapping.channelId}>` : (repository.notificationChannelId ? `<#${repository.notificationChannelId}> (default)` : 'Not set (default channel pending)'), inline: true }
+        )
+        .setFooter({ text: 'Changes are saved immediately when you toggle buttons.' })
+        .setTimestamp();
+
+      const buildRows = () => {
+        const rows = [];
+        let row = new ActionRowBuilder();
+        let count = 0;
+        for (const action of supportedActions) {
+          const enabled = Boolean(actionsEnabled[action]);
+          const btn = new ButtonBuilder()
+            .setCustomId(`edit_evt:${repository.id}:${eventType}:${action}`)
+            .setLabel(`${action}`)
+            .setStyle(enabled ? ButtonStyle.Success : ButtonStyle.Secondary);
+          if (count === 5) { // discord max 5 buttons per row
+            rows.push(row);
+            row = new ActionRowBuilder();
+            count = 0;
+          }
+          row.addComponents(btn);
+          count += 1;
+        }
+        if (count > 0) rows.push(row);
+        // Add a close row
+        rows.push(new ActionRowBuilder().addComponents(
+          new ButtonBuilder().setCustomId(`edit_evt_close:${repository.id}:${eventType}`).setLabel('Close').setStyle(ButtonStyle.Danger)
+        ));
+        return rows;
+      };
+
+      const message = await interaction.editReply({ embeds: [embed], components: buildRows() });
+
+      const collector = message.createMessageComponentCollector({ time: 60_000 });
+
+      collector.on('collect', async (i) => {
+        if (i.user.id !== interaction.user.id) {
+          await i.reply({ content: 'Only the command user can change these settings.', ephemeral: true });
+          return;
+        }
+
+        // Close button
+        if (i.customId.startsWith('edit_evt_close:')) {
+          collector.stop('closed');
+          await i.update({ components: [] });
+          return;
+        }
+
+        const parts = i.customId.split(':');
+        if (parts.length !== 4 || parts[0] !== 'edit_evt') {
+          await i.deferUpdate();
+          return;
+        }
+        const [, repoId, evtType, action] = parts;
+        if (repoId !== repository.id || evtType !== eventType) {
+          await i.deferUpdate();
+          return;
+        }
+
+        const enabledNow = !Boolean(actionsEnabled[action]);
+        actionsEnabled[action] = enabledNow;
+
+        // Persist immediately (upsert mapping if missing, using fallback/default channel)
+        if (mapping) {
+          await prisma.repositoryEventChannel.update({
+            where: { id: mapping.id },
+            data: { config: { actionsEnabled } }
+          });
+        } else {
+          await prisma.repositoryEventChannel.create({
+            data: {
+              repositoryId: repository.id,
+              eventType,
+              channelId: repository.notificationChannelId || 'pending',
+              config: { actionsEnabled }
+            }
+          });
+        }
+
+        // Re-render buttons
+        await i.update({ components: buildRows() });
+      });
+
+      collector.on('end', async () => {
+        try {
+          await interaction.editReply({ components: [] });
+        } catch {}
+      });
+    } catch (error) {
+      console.error('Error in /edit-event:', error);
+      const embed = new EmbedBuilder()
+        .setColor(0xEF4444)
+        .setTitle('Failed to open editor')
+        .setDescription(`An error occurred: \`${error.message}\``);
+      await interaction.editReply({ embeds: [embed], components: [] });
+    }
+  }
+};
+
+

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -32,6 +32,7 @@ module.exports = {
             '• `/remove-repo` - Remove a repository from tracking\n' +
             '• `/set-default-channel` - Set the default notification channel\n' +
             '• `/set-event-channel` - Route a specific event (e.g., issues, release) to a channel\n' +
+            '• `/edit-event` - Configure filters for a routed event (e.g., only issues opened, no comments)\n' +
             '• `/remove-event-channel` - Remove a specific event route from a repository\n' +
             '• `/reset` - Reset all bot data for this server (Admin only)',
           inline: false

--- a/src/commands/set-event-channel.js
+++ b/src/commands/set-event-channel.js
@@ -9,7 +9,6 @@ const ROUTABLE_EVENTS = [
   { name: 'create', value: 'create' },
   { name: 'delete', value: 'delete' },
   { name: 'pull_request', value: 'pull_request' },
-  { name: 'issue_comment', value: 'issue_comment' },
   { name: 'milestone', value: 'milestone' },
   { name: 'ping', value: 'ping' },
 ];


### PR DESCRIPTION
- Add /edit-event with interactive toggles for non-branch events
- Works even without event route (falls back to repo default channel)
- Unify issue comments under issues with a single “comments” toggle
- Route PR conversation comments via pull_request config; add PR “comments” toggle
- Enforce strict opt-in: only send when explicitly enabled in config
- Support unstar (star deleted)
- Map unassigned→assigned, unlabeled→labeled
- Update /help and README
- Prisma: add RepositoryEventChannel.config (JSON) for action filters