### PR TITLE
fix: ensure database schema is created before app starts in dev

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -20,7 +20,8 @@ services:
       # Hot reloading: Mount source code for live updates
       - ..:/usr/src/app
       - /usr/src/app/node_modules
-    command: npm run dev
+    command: >
+      sh -c "npx prisma db push && npm run dev"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,18 +47,6 @@ docker-compose -f docker/docker-compose.dev.yml up -d
 echo "⏳ Waiting for services to be ready..."
 sleep 10
 
-# Setup database schema
-echo "🗄️ Setting up database schema..."
-docker-compose -f docker/docker-compose.dev.yml exec bot sh -c "
-  if [ -d 'prisma/migrations' ] && [ \"\$(ls -A prisma/migrations)\" ]; then
-    echo 'Using migrations...'
-    npx prisma migrate deploy
-  else
-    echo 'No migrations found, using db push...'
-    npx prisma db push
-  fi
-"
-
 # Check if services are running
 echo "🔍 Checking service status..."
 docker-compose -f docker/docker-compose.dev.yml ps


### PR DESCRIPTION
- Modified docker-compose.dev.yml to run 'npx prisma db push' before 'npm run dev'
- Removed separate schema setup from deploy.sh since it's now handled at container startup
- Prevents 'table does not exist' errors during development startup