### PR TITLE
feat: add Prisma Studio to development environment

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
       - PORT=3000
     ports:
       - "3000:3000"
+      - "5555:5555"
     depends_on:
       postgres:
         condition: service_healthy
@@ -21,7 +22,7 @@ services:
       - ..:/usr/src/app
       - /usr/src/app/node_modules
     command: >
-      sh -c "npx prisma db push && npm run dev"
+      sh -c "npx prisma db push && (npm run dev & npx prisma studio --browser none) && wait"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -53,4 +53,5 @@ docker-compose -f docker/docker-compose.dev.yml ps
 
 echo "✅ GitTrack Discord Bot deployed successfully!"
 echo "🌐 Bot is running on http://localhost:3000"
+echo "🗄️ Prisma Studio is running on http://localhost:5555"
 echo "📊 Check logs with: docker-compose -f docker/docker-compose.dev.yml logs -f bot" 


### PR DESCRIPTION
- Add port forwarding for Prisma Studio (5555:5555)
- Run Prisma Studio automatically alongside the bot in dev mode
- Update deploy script to show Prisma Studio access URL
- Developers can now access database GUI at http://localhost:5555