### PR TITLE
Feat: Nicer workflow embed

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -37,6 +37,7 @@ services:
     container_name: gittrack-postgres
     restart: unless-stopped
     environment:
+      # - DATABASE_URL=postgresql://gittrack:password@localhost:5432/gittrack
       - POSTGRES_DB=gittrack
       - POSTGRES_USER=gittrack
       - POSTGRES_PASSWORD=password

--- a/src/handlers/milestoneAndWorkflowHandlers.js
+++ b/src/handlers/milestoneAndWorkflowHandlers.js
@@ -231,9 +231,7 @@ async function handleWorkflowRunEvent(req, res, payload, prisma, botClient, repo
           let jobField = null;
           try {
             const jobsResponse = await fetch(jobsUrl);
-            console.log("jobsResponse: " + JSON.stringify(jobsResponse));
             if (jobsResponse.ok) {
-              console.log("jobsResponse.jobs exists");
               const jobsData = await jobsResponse.json();
               if(jobsData?.jobs && jobsData.jobs.length > 0) {
                 jobField = analyzeJobs(jobsData?.jobs);

--- a/src/handlers/milestoneAndWorkflowHandlers.js
+++ b/src/handlers/milestoneAndWorkflowHandlers.js
@@ -342,7 +342,7 @@ function analyzeJobs(jobs) {
   const maxNameLength = Math.max(0, ...entries.map(({ name }) => name.length));
   const formatted = entries.map(({ indicator, name, right }) => {
     const paddedName = name.padEnd(maxNameLength, '    ');
-    const left = `\u001b[1;33m${paddedName}\u001b[0m`;
+    const left = `\u001b[1;2m${paddedName}\u001b[0m`;
     return {
       left,
       right,

--- a/src/handlers/milestoneAndWorkflowHandlers.js
+++ b/src/handlers/milestoneAndWorkflowHandlers.js
@@ -305,7 +305,7 @@ function analyzeJobs(jobs) {
     failure: { indicator: '✗', label: 'Failed', color: 'red' },
     cancelled: { indicator: '⬣', label: 'Cancelled', color: 'yellow' },
     skipped: { indicator: '➤', label: 'Skipped', color: 'blue' },
-    timed_out: { indicator: '🕒', label: 'Timed out', color: 'orange' }
+    timed_out: { indicator: '🕒', label: 'Timed out', color: 'yellow' }
   };
 
   let passed = 0;

--- a/src/handlers/milestoneAndWorkflowHandlers.js
+++ b/src/handlers/milestoneAndWorkflowHandlers.js
@@ -335,11 +335,15 @@ function analyzeJobs(jobs) {
     };
   });
 
+  // stop if no entries
   if (entries.length === 0) {
     return null;
   }
 
+  // Determine padding for alignment
   const maxNameLength = Math.max(0, ...entries.map(({ name }) => name.length));
+
+  // Format each entry with padding and ANSI codes
   const formatted = entries.map(({ indicator, name, right }) => {
     const paddedName = name.padEnd(maxNameLength, '    ');
     const left = `\u001b[1;2m${paddedName}\u001b[0m`;
@@ -349,25 +353,31 @@ function analyzeJobs(jobs) {
     };
   });
 
+  // Determine box width for alignment
   const boxWidth =
     Math.max(...formatted.map(({ left, right }) => left.length + right.length)) + 2;
 
+  // Create lines with proper spacing
   const lines = formatted.map(({ left, right }) => {
     const spacing = Math.max(1, boxWidth - left.length - right.length);
     return `${left}${' '.repeat(spacing)}${right}`;
   });
 
+  // Prepare header with summary
   const passedString = wrapAnsi(`${passed} passed`, 'green');
   const failedString = failed > 0 ? wrapAnsi(`${failed} failed`, 'red') : `${failed} failed`;
-
   const header = `${passedString} · ${failedString}`;
 
+  // Wrap lines in ANSI code block
+  
   const wrapLines = (lineArray) =>
     `\`\`\`ansi\n\n${header}\n${lineArray.join('\n')}\n\`\`\``;
 
   let value = wrapLines(lines);
   let truncated = false;
 
+  // Ensure total length does not exceed 1024 characters
+  // If too long, truncate lines from the end and add ellipsis line
   while (value.length > 1024 && lines.length > 0) {
     lines.pop();
     truncated = true;
@@ -389,6 +399,7 @@ function analyzeJobs(jobs) {
   return { name: 'Jobs', value, inline: false };
 }
 
+// Format duration between two ISO date strings into "Xm Ys" format
 function formatDuration(start, end) {
   if (!start || !end) {
     return '';
@@ -406,13 +417,14 @@ function formatDuration(start, end) {
   return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
 }
 
-
+// Wrap text in ANSI color codes
 function wrapAnsi(text, color) {
   if (!text) return '';
   const code = /^\d+$/.test(color) ? color : ansiColorCode(color);
   return `\u001b[2;${code}m${text}\u001b[0m`;
 }
 
+// Map color names to ANSI codes
 function ansiColorCode(colorName) {
   switch ((colorName || '').toLowerCase()) {
     case 'green':
@@ -434,9 +446,6 @@ function ansiColorCode(colorName) {
       return '37';
   }
 }
-
-
-
 
 module.exports = {
   handleMilestoneEvent,


### PR DESCRIPTION
This PR adds more details to the Workflow Run embed by getting all related jobs and displaying them inside a ANSI Code block.

If a Repo is private it skips the entire process.

Some examples for reference:

<img width="338" height="272" alt="Bildschirmfoto 2025-10-02 um 21 59 25" src="https://github.com/user-attachments/assets/6c1b2691-6398-4dfb-96d6-6215067f4f01" />
<img width="319" height="274" alt="Bildschirmfoto 2025-10-02 um 22 07 08" src="https://github.com/user-attachments/assets/20ba9c18-8299-4629-ad94-67382e9d834b" />
<img width="343" height="280" alt="Bildschirmfoto 2025-10-02 um 22 07 13" src="https://github.com/user-attachments/assets/24e7b89f-8516-4195-a380-e044cf885329" />
<img width="344" height="281" alt="Bildschirmfoto 2025-10-02 um 22 09 30" src="https://github.com/user-attachments/assets/49996ee4-f073-4495-ab10-692b457fac04" />


This also adds a optional DATABASE_URL Tag to the docker-compose.dev.yml 