### PR TITLE
Fix/strip html comments from notifications

### DIFF
--- a/src/functions/sanitizeBody.js
+++ b/src/functions/sanitizeBody.js
@@ -1,0 +1,14 @@
+/**
+ * Strip HTML comments (<!-- ... -->) from a string.
+ *
+ * GitHub issue/PR templates commonly include HTML comments as hints to the
+ * author. GitHub hides them when rendering, but they remain in the raw
+ * `body` field we get from webhooks — so we remove them before forwarding
+ * text into Discord embeds.
+ */
+function stripHtmlComments(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(/<!--[\s\S]*?-->/g, '').trim();
+}
+
+module.exports = { stripHtmlComments };

--- a/src/functions/sanitizeBody.js
+++ b/src/functions/sanitizeBody.js
@@ -7,7 +7,9 @@
  * text into Discord embeds.
  */
 function stripHtmlComments(text) {
-  if (typeof text !== 'string') return '';
+  if (typeof text !== 'string') {
+    return '';
+  }
   return text.replace(/<!--[\s\S]*?-->/g, '').trim();
 }
 

--- a/src/handlers/pullRequestHandlers.js
+++ b/src/handlers/pullRequestHandlers.js
@@ -4,6 +4,7 @@
  */
 
 const { getEventRouting } = require('../functions/eventRouting');
+const { stripHtmlComments } = require('../functions/sanitizeBody');
 
 /**
  * Handles pull request review events
@@ -96,10 +97,12 @@ async function handlePRReviewEvent(req, res, payload, prisma, botClient, repoCon
 
       // Add review comments if available
       if (payload.review.body) {
-        const reviewBody = payload.review.body;
-        embed.description = reviewBody.length > 300
-          ? reviewBody.substring(0, 300) + '...'
-          : reviewBody;
+        const reviewBody = stripHtmlComments(payload.review.body);
+        if (reviewBody) {
+          embed.description = reviewBody.length > 300
+            ? reviewBody.substring(0, 300) + '...'
+            : reviewBody;
+        }
       }
 
       const sentMessage = await channel.send({ embeds: [embed] });
@@ -137,7 +140,7 @@ async function handlePRReviewCommentEvent(req, res, payload, prisma, botClient, 
   const prNumber = payload.pull_request.number;
   const prTitle = payload.pull_request.title;
   const commentUrl = payload.comment.html_url;
-  const commentBody = payload.comment.body || '';
+  const commentBody = stripHtmlComments(payload.comment.body);
   const path = payload.comment.path; // File being commented on
 
   console.log(`PR Review Comment ${action} on PR #${prNumber} in ${repoUrl} by ${username}`);

--- a/src/handlers/webhookHandler.js
+++ b/src/handlers/webhookHandler.js
@@ -7,6 +7,7 @@ const { handlePRReviewEvent, handlePRReviewCommentEvent } = require('./pullReque
 const { checkChannelLimit } = require('../functions/limitChecker');
 const { findMatchingBranches } = require('../functions/branchMatcher');
 const { getEventRouting } = require('../functions/eventRouting');
+const { stripHtmlComments } = require('../functions/sanitizeBody');
 
 function initializeWebServer(prisma, botClient) {
   const app = express();
@@ -316,11 +317,13 @@ function initializeWebServer(prisma, botClient) {
         };
 
         if (payload.comment.body) {
-          let commentBody = payload.comment.body;
-          if (commentBody.length > 1000) {
-            commentBody = commentBody.substring(0, 997) + '...';
+          let commentBody = stripHtmlComments(payload.comment.body);
+          if (commentBody) {
+            if (commentBody.length > 1000) {
+              commentBody = commentBody.substring(0, 997) + '...';
+            }
+            embed.description = commentBody;
           }
-          embed.description = commentBody;
         }
 
         const sentMessage = await channel.send({ embeds: [embed] });
@@ -522,7 +525,7 @@ function initializeWebServer(prisma, botClient) {
           footer: { text: `GitHub Pull Request` }
         };
         // ... (rest of embed construction from original)
-        if (pr.body) { let prBody = pr.body; if (prBody.length > 300) { prBody = prBody.substring(0, 297) + '...'; } embed.description = prBody; }
+        if (pr.body) { let prBody = stripHtmlComments(pr.body); if (prBody) { if (prBody.length > 300) { prBody = prBody.substring(0, 297) + '...'; } embed.description = prBody; } }
         if (action === 'closed' && pr.merged) { embed.fields.push({ name: 'Merged by', value: pr.merged_by.login, inline: true }); }
         if (action === 'assigned' && payload.assignee) { embed.description = `${pr.user.login} assigned ${payload.assignee.login}.`; }
         // ... (other action specific descriptions)
@@ -595,7 +598,7 @@ function initializeWebServer(prisma, botClient) {
           footer: { text: `GitHub Issue` }
         };
         // ... (rest of embed construction from original)
-        if (issue.body) { let issueBody = issue.body; if (issueBody.length > 300) { issueBody = issueBody.substring(0, 297) + '...'; } embed.description = issueBody; }
+        if (issue.body) { let issueBody = stripHtmlComments(issue.body); if (issueBody) { if (issueBody.length > 300) { issueBody = issueBody.substring(0, 297) + '...'; } embed.description = issueBody; } }
         if (issue.labels && issue.labels.length > 0) { embed.fields.push({ name: 'Labels', value: issue.labels.map(l => `\`${l.name}\``).join(', '), inline: true }); }
         // ... (other action specific descriptions)
 
@@ -719,7 +722,7 @@ function initializeWebServer(prisma, botClient) {
           timestamp: release.published_at || new Date().toISOString(),
           footer: { text: `GitHub Release` }
         };
-        if (release.body) { let body = release.body; if (body.length > 1500) {body = body.substring(0, 1497) + '...';} embed.description = body; }
+        if (release.body) { let body = stripHtmlComments(release.body); if (body) { if (body.length > 1500) {body = body.substring(0, 1497) + '...';} embed.description = body; } }
         const sentMessage = await channel.send({ embeds: [embed] });
         console.log(`Sent release notification to channel ${channelId} in guild ${serverConfig.guildId}`);
 

--- a/tests/sanitizeBody.test.js
+++ b/tests/sanitizeBody.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stripHtmlComments } = require('../src/functions/sanitizeBody');
+
+test('stripHtmlComments removes a single HTML comment', () => {
+  assert.equal(
+    stripHtmlComments('<!-- hidden hint -->actual body'),
+    'actual body'
+  );
+});
+
+test('stripHtmlComments removes multiple HTML comments', () => {
+  const input = '<!-- a -->one<!-- b -->two<!-- c -->';
+  assert.equal(stripHtmlComments(input), 'onetwo');
+});
+
+test('stripHtmlComments removes multi-line HTML comments (typical issue template)', () => {
+  const input = [
+    '<!--',
+    '  Please describe the bug you are experiencing.',
+    '  Include steps to reproduce.',
+    '-->',
+    '',
+    'The app crashes when I click Save.'
+  ].join('\n');
+
+  assert.equal(stripHtmlComments(input), 'The app crashes when I click Save.');
+});
+
+test('stripHtmlComments trims surrounding whitespace left behind', () => {
+  const input = '\n\n<!-- remove me -->\n\nHello\n\n';
+  assert.equal(stripHtmlComments(input), 'Hello');
+});
+
+test('stripHtmlComments returns empty string when the body is only a comment', () => {
+  assert.equal(stripHtmlComments('<!-- only comment -->'), '');
+  assert.equal(stripHtmlComments('   <!-- a -->\n<!-- b -->   '), '');
+});
+
+test('stripHtmlComments leaves bodies without comments unchanged (aside from trim)', () => {
+  assert.equal(stripHtmlComments('No comments here.'), 'No comments here.');
+  assert.equal(stripHtmlComments('  padded  '), 'padded');
+});
+
+test('stripHtmlComments is non-greedy across adjacent comments', () => {
+  const input = '<!-- first -->keep<!-- second -->';
+  assert.equal(stripHtmlComments(input), 'keep');
+});
+
+test('stripHtmlComments preserves markdown and code fences that are not comments', () => {
+  const input = '# Title\n\n```js\nconst x = 1; // not an html comment\n```';
+  assert.equal(stripHtmlComments(input), input);
+});
+
+test('stripHtmlComments handles non-string input defensively', () => {
+  assert.equal(stripHtmlComments(undefined), '');
+  assert.equal(stripHtmlComments(null), '');
+  assert.equal(stripHtmlComments(123), '');
+});


### PR DESCRIPTION
## Summary
- GitHub issue/PR templates use HTML comment syntax as hints to the author. GitHub hides them when rendering, but they were being forwarded verbatim into Discord embeds.
- Added `stripHtmlComments()` helper in `functions/sanitizeBody.js` and applied it to issue, PR, release, issue-comment, PR-review, and PR-review-comment bodies.
- Added unit tests covering single/multiple/multi-line comments, adjacent-comment non-greediness, whitespace trimming, all-comment bodies, and defensive handling of non-string input.