### PR TITLE
Allow usage of Announcement channels

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { checkRepositoryLimit, checkChannelLimit } = require('../functions/limitChecker');
 const { isValidBranchPattern } = require('../functions/branchMatcher');
+const { getChannelPermissionWarning } = require('../functions/permissionChecker');
 
 // Helper function to extract owner and repo from GitHub URL
 function extractOwnerAndRepo(url) {
@@ -100,6 +101,10 @@ module.exports = {
       await interaction.editReply('The selected channel must be a text-based channel.');
       return;
     }
+
+    // Warn (without blocking) if the bot cannot post in the selected channel
+    const permissionWarning = getChannelPermissionWarning(notificationChannel, interaction.guild);
+    const permissionNote = permissionWarning ? `\n\n${permissionWarning}` : '';
 
     // Validate branch pattern
     if (!isValidBranchPattern(branchName)) {
@@ -225,7 +230,7 @@ module.exports = {
 
         if (existingWildcard) {
           await interaction.editReply(
-            `All branches are already being tracked for repository <${standardizedUrl}> in channel ${notificationChannel}.`
+            `All branches are already being tracked for repository <${standardizedUrl}> in channel ${notificationChannel}.${permissionNote}`
           );
           return;
         }
@@ -241,7 +246,7 @@ module.exports = {
 
         if (deletedBranches.count > 0) {
           await interaction.editReply(
-            `Removed ${deletedBranches.count} specific branch tracking rules and now tracking all branches for repository <${standardizedUrl}> in channel ${notificationChannel}.`
+            `Removed ${deletedBranches.count} specific branch tracking rules and now tracking all branches for repository <${standardizedUrl}> in channel ${notificationChannel}.${permissionNote}`
           );
           return;
         }
@@ -257,7 +262,7 @@ module.exports = {
 
         if (existingBranch) {
           await interaction.editReply(
-            `Branch \`${branchName}\` is already being tracked for repository <${standardizedUrl}> in channel ${notificationChannel}.`
+            `Branch \`${branchName}\` is already being tracked for repository <${standardizedUrl}> in channel ${notificationChannel}.${permissionNote}`
           );
           return;
         }
@@ -287,7 +292,7 @@ module.exports = {
 
       await interaction.editReply(
         `✅ Successfully linked **${branchDescription}** from repository <${standardizedUrl}> to channel ${notificationChannel}.\n\n` +
-        `You will now receive notifications matching this pattern in the specified channel.`
+        `You will now receive notifications matching this pattern in the specified channel.${permissionNote}`
       );
 
     } catch (error) {

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
 const { checkRepositoryLimit, checkChannelLimit } = require('../functions/limitChecker');
 const { isValidBranchPattern } = require('../functions/branchMatcher');
 
@@ -67,7 +67,7 @@ module.exports = {
     .addChannelOption(option =>
       option.setName('channel')
         .setDescription('The channel where notifications for this repository will be sent.')
-        .addChannelTypes(0) // GuildText only
+        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement) // Text and Announcement channels
         .setRequired(true)),
 
   async execute(interaction, prisma) {

--- a/src/commands/set-default-channel.js
+++ b/src/commands/set-default-channel.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
+const { getChannelPermissionWarning } = require('../functions/permissionChecker');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -93,8 +94,11 @@ module.exports = {
         data: { notificationChannelId: channel.id }
       });
 
+      const permissionWarning = getChannelPermissionWarning(channel, interaction.guild);
+      const permissionNote = permissionWarning ? `\n\n${permissionWarning}` : '';
+
       await interaction.editReply(
-        `Default notification channel for repository \`${repository.url}\` has been set to ${channel}. This channel will be used for all repository-wide GitHub notifications.`
+        `Default notification channel for repository \`${repository.url}\` has been set to ${channel}. This channel will be used for all repository-wide GitHub notifications.${permissionNote}`
       );
     } catch (error) {
       console.error('Error setting repository default channel:', error);

--- a/src/commands/set-event-channel.js
+++ b/src/commands/set-event-channel.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
 
 // Event types eligible for per-event routing (non-branch specific)
 const ROUTABLE_EVENTS = [
@@ -37,7 +37,7 @@ module.exports = {
     .addChannelOption(option =>
       option.setName('channel')
         .setDescription('Channel to send this event to')
-        .addChannelTypes(0) // GuildText only
+        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement) // Text and Announcement channels
         .setRequired(true)
     ),
 

--- a/src/commands/set-event-channel.js
+++ b/src/commands/set-event-channel.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
+const { getChannelPermissionWarning } = require('../functions/permissionChecker');
 
 // Event types eligible for per-event routing (non-branch specific)
 const ROUTABLE_EVENTS = [
@@ -90,6 +91,9 @@ module.exports = {
       return;
     }
 
+    // Warn (without blocking) if the bot cannot post in the selected channel
+    const permissionWarning = getChannelPermissionWarning(channel, interaction.guild);
+
     if (repositoryId === 'no-repos' || repositoryId === 'no-match' || repositoryId === 'error') {
       await interaction.editReply('Please set up a repository first using the /setup command.');
       return;
@@ -154,7 +158,7 @@ module.exports = {
         .setFooter({ text: 'Use /status to view all event routes and branch links.' })
         .setTimestamp();
 
-      await interaction.editReply({ embeds: [embed] });
+      await interaction.editReply({ content: permissionWarning || undefined, embeds: [embed] });
     } catch (error) {
       console.error('Error setting event channel:', error);
       const embed = new EmbedBuilder()

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
 const { checkRepositoryLimit } = require('../functions/limitChecker');
+const { getChannelPermissionWarning } = require('../functions/permissionChecker');
 const crypto = require('crypto');
 
 // Helper function to generate a random webhook secret
@@ -31,6 +32,9 @@ module.exports = {
     
     // Use the channel where the command was called from if no channel is specified
     const notificationChannel = setupChannel || interaction.channel;
+
+    // Warn (without blocking) if the bot cannot post in the notification channel
+    const permissionWarning = getChannelPermissionWarning(notificationChannel, interaction.guild);
 
     // Basic URL validation
     try {
@@ -217,8 +221,9 @@ module.exports = {
         })
         .setTimestamp();
 
-      await interaction.editReply({ 
-        embeds: [embed] 
+      await interaction.editReply({
+        content: permissionWarning || undefined,
+        embeds: [embed]
       });
 
     } catch (error) {

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
 const { checkRepositoryLimit } = require('../functions/limitChecker');
 const crypto = require('crypto');
 
@@ -18,7 +18,7 @@ module.exports = {
     .addChannelOption(option =>
       option.setName('channel')
         .setDescription('The default channel for repository notifications (optional - defaults to current channel)')
-        .addChannelTypes(0) // GuildText only
+        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement) // Text and Announcement channels
         .setRequired(false)),
   
   async execute(interaction, prisma) {

--- a/src/functions/permissionChecker.js
+++ b/src/functions/permissionChecker.js
@@ -1,3 +1,4 @@
+const { ChannelType, PermissionFlagsBits } = require('discord.js');
 
 /**
  * Checks if a user has any of the following:
@@ -21,4 +22,41 @@ function checkPermissions(interaction) {
   return false;
 }
 
-module.exports = { checkPermissions };
+// Permissions the bot needs in a channel to deliver notification embeds
+const REQUIRED_CHANNEL_PERMISSIONS = [
+  { flag: PermissionFlagsBits.ViewChannel, name: 'View Channel' },
+  { flag: PermissionFlagsBits.SendMessages, name: 'Send Messages' },
+  { flag: PermissionFlagsBits.EmbedLinks, name: 'Embed Links' },
+];
+
+/**
+ * Checks whether the bot itself can deliver notifications to the given channel.
+ *
+ * @param {import('discord.js').GuildBasedChannel} channel The target notification channel
+ * @param {import('discord.js').Guild} guild The guild the channel belongs to
+ * @returns {String|null} A user-facing warning listing the missing permissions, or null if none are missing
+ */
+function getChannelPermissionWarning(channel, guild) {
+  const me = guild?.members?.me;
+  if (!me || typeof channel?.permissionsFor !== 'function') {
+    return null;
+  }
+
+  const perms = channel.permissionsFor(me);
+  const missing = REQUIRED_CHANNEL_PERMISSIONS.filter(p => !perms || !perms.has(p.flag));
+  if (missing.length === 0) {
+    return null;
+  }
+
+  const missingNames = missing.map(p => `**${p.name}**`).join(', ');
+  const announcementNote = channel.type === ChannelType.GuildAnnouncement
+    ? ' Note: announcement channels deny posting to everyone by default.'
+    : '';
+  return (
+    `⚠️ I'm missing ${missingNames} in ${channel}, so notifications cannot be delivered there. ` +
+    `Grant these permissions to my role in that channel's settings (Edit Channel → Permissions).` +
+    announcementNote
+  );
+}
+
+module.exports = { checkPermissions, getChannelPermissionWarning };


### PR DESCRIPTION
I feel it’s very limiting to not being able to select announcement channels with the bot as I‘d like releases for example to be posted in one. This PR removes/extends that limitation by allowing the selection of announcement channels in addition to normal text channels in commands.

I haven’t been able to test this but if someone could, I‘d be happy.